### PR TITLE
Add persistent option to bottom sheet

### DIFF
--- a/lib/core/helpers/engine_bottomsheet.dart
+++ b/lib/core/helpers/engine_bottomsheet.dart
@@ -6,9 +6,14 @@ import 'package:get/get.dart';
 class EngineBottomsheet<T> {
   EngineBottomsheet._();
 
+  /// Displays a bottom sheet.
+  ///
+  /// Set [persistent] to keep the bottom sheet visible when navigating
+  /// to a new route.
   static Future<T?> show<T>({
     required final Widget content,
     final bool isDismissible = true,
+    final bool persistent = false,
     final bool enableDrag = true,
     final bool isScrollControlled = false,
     final bool needPageIsLoaded = false,
@@ -17,6 +22,7 @@ class EngineBottomsheet<T> {
     if (!needPageIsLoaded) {
       return await _makeBottomsheet(
         content: content,
+        persistent: persistent,
         enableDrag: enableDrag,
         isDismissible: isDismissible,
         isScrollControlled: isScrollControlled,
@@ -28,15 +34,17 @@ class EngineBottomsheet<T> {
       (final _) async {
         final result = await _makeBottomsheet(
           content: content,
+          persistent: persistent,
           enableDrag: enableDrag,
           isDismissible: isDismissible,
           isScrollControlled: isScrollControlled,
           onClose: onClose,
         );
 
-        if (result == null && !isDismissible) {
+        if (result == null && persistent) {
           return _makeBottomsheet(
             content: content,
+            persistent: persistent,
             enableDrag: enableDrag,
             isDismissible: isDismissible,
             isScrollControlled: isScrollControlled,
@@ -49,9 +57,11 @@ class EngineBottomsheet<T> {
     return null;
   }
 
+  /// Internal method that actually shows the bottom sheet.
   static Future<T?> _makeBottomsheet<T>({
     required final Widget content,
     required final bool isDismissible,
+    required final bool persistent,
     required final bool enableDrag,
     required final bool isScrollControlled,
     final VoidCallback? onClose,
@@ -61,7 +71,7 @@ class EngineBottomsheet<T> {
       isDismissible: isDismissible,
       enableDrag: enableDrag,
       isScrollControlled: isScrollControlled,
-      persistent: isDismissible,
+      persistent: persistent,
     ).whenComplete(() => onClose?.call());
     return result;
   }


### PR DESCRIPTION
## Summary
- make persistence optional in `EngineBottomsheet.show`
- support dedicated `persistent` parameter in `_makeBottomsheet`
- document how to keep the bottom sheet visible when navigating

## Testing
- `dart format --output=none --set-exit-if-changed lib/core/helpers/engine_bottomsheet.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684592ac17b4832ebd02a3735474606f